### PR TITLE
apps/maze: fix possible stack overflow

### DIFF
--- a/apps/maze/maze.c
+++ b/apps/maze/maze.c
@@ -42,7 +42,7 @@ void carve(int x, int y) {
     int dirs[] = {0, 1, 2, 3};
     // Fisher-Yates shuffle
     for (int i = 3; i > 0; i--) {
-        int j = mulberry32() % (i + 1);
+        int j = (unsigned)mulberry32() % (i + 1);
         int tmp = dirs[i];
         dirs[i] = dirs[j];
         dirs[j] = tmp;


### PR DESCRIPTION
I used your maze example to test my very own RISC-V emulator, which for some reason kept crashing when being compiled with anything greater than -O0, and I've spent 3 hours trying to figure out where the bug is — and it is in this code snippet! :)

The original code this app is inspired from, mentioned at the top of the file, uses rand(), which returns a number >= 0.
mulberry32() on the other hand can return a negative number, in which case will overflow the accesses in the dirs array. Apparently this wasn't reproducible unless optimizations were turned on.

I know it's such a small part of your project, but perhaps this'll save some headache to anyone using your examples to test their RISC-V emulators!