### PR TITLE
Rust VM application generates .eh_frame section

### DIFF
--- a/apps/common/linker.ld
+++ b/apps/common/linker.ld
@@ -33,6 +33,7 @@ SECTIONS
 		*(.dynsym)
 		*(.dynstr)
 		*(.header)
+		*(.eh_frame)
 	} : phdr
 
 	.data : ALIGN(16) {


### PR DESCRIPTION
Hi, I am currently testing uvm32 with some Rust vm apps. 

I found a problem if the rust app gets a bit more complex then the "Hello World" example an .eh_frame section is generated in the compiled ELF.

The section was ~30 bytes long and was places **before** my .text section in the .bin file after objcopy.
This lead to an invalid opcode error when loading the file.

This took my by surprise since the smaller rust application worked just fine.

The .eh-frame is for exception handling and can probably safly discarded for this uvm32 usecase:
[linuxfoundation ehframe](https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html)

It's only a small change but I hope it will help others avoid the same Issue